### PR TITLE
Require SilverStripe Framework (instead of CMS+Framework)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.4",
-        "silverstripe/recipe-cms": "^4.0",
+        "silverstripe/recipe-core": "^4.0",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
[`silverstripe-shorturls`](https://github.com/dynamic/silverstripe-shorturls) works perfectly without the CMS.

This commit allows framework-only users to use the module without the CMS.