### PR TITLE
feat: Silverstripe 6 compatibility (4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,4 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      phpcoverage: true
+    

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create short URLs via Bit.ly, tagged with Google Analytics Campaign data.
 
 ## Requirements
 
-- SilverStripe 4
+- Silverstripe ^6
 - guzzlehttp/guzzle ^7.4
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "guzzlehttp/guzzle": "^7.4",
         "silverstripe/recipe-core": "^4.0",
-        "silverstripe/vendor-plugin": "^1.0"
+        "silverstripe/vendor-plugin": "^1.0 || ^2.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^2"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.4",
-        "silverstripe/recipe-cms": "^4.0",
+        "silverstripe/recipe-core": "^4.0",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.4",
-        "silverstripe/recipe-core": "^4.0",
+        "silverstripe/recipe-core": "^4.0 || ^5.0",
         "silverstripe/vendor-plugin": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^2"
+        "silverstripe/recipe-testing": "^2 || ^3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.4",
-        "silverstripe/recipe-core": "^4.0 || ^5.0",
-        "silverstripe/vendor-plugin": "^1.0 || ^2.0"
+        "silverstripe/recipe-core": "^4.0 || ^5.0 || ^6.0",
+        "silverstripe/vendor-plugin": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^2 || ^3"
+        "silverstripe/recipe-testing": "^2 || ^3 || ^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^7.4",
-        "silverstripe/recipe-core": "^4.0 || ^5.0 || ^6.0",
-        "silverstripe/vendor-plugin": "^1.0 || ^2.0 || ^3.0"
+        "silverstripe/recipe-core": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^2 || ^3 || ^4"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -34,11 +34,11 @@
         }
     },
     "config": {
-        "allow-plugins": {
-            "composer/installers": true,
-            "silverstripe/vendor-plugin": true,
-            "silverstripe/recipe-plugin": true
-        },
         "process-timeout": 600
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.x-dev"
+        }
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,6 @@
     <file>src</file>
     <file>tests</file>
 
-    <!-- base rules are PSR-2 -->
     <rule ref="PSR2" >
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
     <testsuites>
-        <testsuite name="elemental-features">
-            <directory>tests/</directory>
+        <testsuite name="Default">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/framework/tests/bootstrap.php"
+         colors="true">
     <testsuites>
-        <testsuite name="Default">
+        <testsuite name="silverstripe-shorturls">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Model/ShortURL.php
+++ b/src/Model/ShortURL.php
@@ -7,7 +7,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Core\Validation\ValidationResult;
 
 class ShortURL extends DataObject
 {

--- a/src/Model/ShortURL.php
+++ b/src/Model/ShortURL.php
@@ -112,7 +112,7 @@ class ShortURL extends DataObject
     /**
      * @return ValidationResult
      */
-    public function validate()
+    public function validate(): ValidationResult
     {
         $result = parent::validate();
 

--- a/src/ORM/SiteTreeDataExtension.php
+++ b/src/ORM/SiteTreeDataExtension.php
@@ -7,10 +7,10 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
 use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use Symbiote\GridFieldExtensions\GridFieldAddExistingSearchButton;
 
-class SiteTreeDataExtension extends DataExtension
+class SiteTreeDataExtension extends Extension
 {
     /**
      * @var array


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 4/5 support. Major version 4.0 requiring Silverstripe 6 only.

## Changes
- composer.json: recipe-core ^6, vendor-plugin ^3, recipe-testing ^4
- DataExtension → Extension migration
- ValidationResult return type for SS6
- phpunit.xml.dist: PHPUnit 11 format
- branch-alias: dev-master → 4.x-dev
- README: updated requirements

## Version History
| Version | Branch | Silverstripe |
|---------|--------|-------------|
| 4.x     | master | ^6          |
| 3.x     | 3      | ^5          |
| 2.x     | 2.0    | ^4          |
